### PR TITLE
fix the random setting to be more balanced

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
 
 async function basicNPCOrders (config) {
   const { common: { storage: { db } }, market } = config
-
+  market.randomVariance = market.randomVariance || 1
   let terminals = await db['rooms.objects'].find({ $and: [{ type: 'terminal' }, { user: { $eq: null } }] })
   let ps = terminals.map(async terminal => {
     let orders = await db['market.orders'].find({ roomName: terminal.room })
@@ -32,10 +32,11 @@ async function basicNPCOrders (config) {
         buy.amount = market.buyAmount
         buy.price = market.buyPrices[mineral]
       } else if (market.priceMode === 'random') {
-        buy.totalAmount = Math.floor(market.buyAmount * Math.random() * 2)
-        buy.remainingAmount = Math.floor(buy.totalAmount * Math.random())
-        buy.amount = Math.floor(buy.remainingAmount * Math.random())
-        buy.price = Math.floor(market.buyPrices[mineral] * Math.random() * 2)
+        let amount = Math.floor(market.buyAmount * (Math.random() * market.randomVariance + (market.randomVariance/2)))
+        buy.totalAmount = amount
+        buy.remainingAmount = amount
+        buy.amount = amount
+        buy.price = market.buyPrices[mineral] * (Math.random() * market.randomVariance + (market.randomVariance/2))
       }
 
       updates.push(buy)
@@ -60,10 +61,11 @@ async function basicNPCOrders (config) {
         sell.amount = market.sellAmount
         sell.price = market.sellPrices[mineral]
       } else if (market.priceMode === 'random') {
-        sell.totalAmount = Math.floor(market.sellAmount * Math.random() * 2)
-        sell.remainingAmount = Math.floor(sell.totalAmount * Math.random())
-        sell.amount = Math.floor(sell.remainingAmount * Math.random())
-        sell.price = Math.floor(market.sellPrices[mineral] * Math.random() * 2)
+        let amount = Math.floor(market.buyAmount * (Math.random() * market.randomVariance + (market.randomVariance/2)))
+        sell.totalAmount = amount
+        sell.remainingAmount = amount
+        sell.amount = amount
+        sell.price = market.sellPrices[mineral] * (Math.random() * market.randomVariance + (market.randomVariance/2))
       }
 
       updates.push(sell)


### PR DESCRIPTION
previous random could often lead to cases of buying 0 amount or for 0 price. With this fix you can configure the random spread.

A price of 1 with variance of 1 is a random price between 0.5 and 1.5, as previously it was between 0 and 2, 0 always inclusive and quite likely.